### PR TITLE
byte to uint8_t for ESP8266 3.0 compatibility

### DIFF
--- a/src/SparkFun_SGP30_Arduino_Library.cpp
+++ b/src/SparkFun_SGP30_Arduino_Library.cpp
@@ -78,11 +78,21 @@ void SGP30::initAirQuality(void)
 //Returns SGP30_SUCCESS if successful or other error code if unsuccessful
 SGP30ERR SGP30::measureAirQuality(void)
 {
+  startAirQuality();
+  delay(12); //Hang out while measurement is taken. datasheet says 10-12ms
+  return getAirQuality();
+
+}
+
+void SGP30::startAirQuality(void)
+{
   _i2cPort->beginTransmission(_SGP30Address);
   _i2cPort->write(measure_air_quality, 2); //command to measure air quality
   _i2cPort->endTransmission();
-  //Hang out while measurement is taken. datasheet says 10-12ms
-  delay(12);
+}
+
+SGP30ERR SGP30::getAirQuality(void)
+{
   //Comes back in 6 bytes, CO2 data(MSB) / data(LSB) / Checksum / TVOC data(MSB) / data(LSB) / Checksum
   uint8_t toRead;
   toRead = _i2cPort->requestFrom(_SGP30Address, (uint8_t)6);
@@ -111,11 +121,21 @@ SGP30ERR SGP30::measureAirQuality(void)
 //Returns SGP30_SUCCESS if successful or other error code if unsuccessful
 SGP30ERR SGP30::getBaseline(void)
 {
+  startGetBaseline();
+  //Hang out while measurement is taken. datasheet says 10ms
+  delay(10);
+  return finishGetBaseline();
+}
+
+void SGP30::startGetBaseline(void)
+{
   _i2cPort->beginTransmission(_SGP30Address);
   _i2cPort->write(get_baseline, 2);
   _i2cPort->endTransmission();
-  //Hang out while measurement is taken. datasheet says 10ms
-  delay(10);
+}
+
+SGP30ERR SGP30::finishGetBaseline(void)
+{
   uint8_t toRead;
   //Comes back in 6 bytes, baselineCO2 data(MSB) / data(LSB) / Checksum / baselineTVOC data(MSB) / data(LSB) / Checksum
   toRead = _i2cPort->requestFrom(_SGP30Address, (uint8_t)6);

--- a/src/SparkFun_SGP30_Arduino_Library.h
+++ b/src/SparkFun_SGP30_Arduino_Library.h
@@ -87,6 +87,8 @@ public:
   //Will give fixed values of CO2=400 and TVOC=0 for first 15 seconds after init
   //returns false if CRC8 check failed and true if successful
   SGP30ERR measureAirQuality(void);
+  void startAirQuality(void);
+  SGP30ERR getAirQuality(void);
 
   //Returns the current calculated baseline from
   //the sensor's dynamic baseline calculations
@@ -95,6 +97,8 @@ public:
   //after soft reset using setBaseline();
   //returns false if CRC8 check failed and true if successful
   SGP30ERR getBaseline(void);
+  void startGetBaseline(void);
+  SGP30ERR finishGetBaseline(void);
 
   //Updates the baseline to a previous baseline
   //Should only use with previously retrieved baselines
@@ -135,7 +139,7 @@ private:
   TwoWire *_i2cPort;
 
   //SGP30's I2C address
-  const byte _SGP30Address = 0x58;
+  const uint8_t _SGP30Address = 0x58;
 
   //Generates CRC8 for SGP30 from lookup table
   uint8_t _CRC8(uint16_t twoBytes);


### PR DESCRIPTION
1) byte to unit8_t for ESP8266 compatibility
2) created additional functions by splitting measureAirQuality and getBaseline into two functions. This allows the main loop to provide the necessary delay timing. To measure airguality, the main loop cancall startAirquality and then later getAirquality. Original function measureAirquality is still available. Similar approach for getBaseline.